### PR TITLE
Support "Active Windows" on CastEfficiencyBar / CooldownBar & generate in ExecuteHelper

### DIFF
--- a/src/analysis/retail/priest/shadow/modules/guide/CooldownGraphSubsection.tsx
+++ b/src/analysis/retail/priest/shadow/modules/guide/CooldownGraphSubsection.tsx
@@ -6,8 +6,9 @@ import TALENTS from 'common/TALENTS/priest';
 import SPELLS from 'common/SPELLS/priest';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
 import CastEfficiencyBar from 'parser/ui/CastEfficiencyBar';
-import { GapHighlight } from 'parser/ui/CooldownBar';
+import { CooldownWindow, fromExecuteRange, GapHighlight } from 'parser/ui/CooldownBar';
 import { Trans } from '@lingui/macro';
+import Voidbolt from '../spells/Voidbolt';
 
 type Cooldown = {
   talent: Talent;
@@ -16,6 +17,7 @@ type Cooldown = {
 
 type SpellCooldown = {
   spell: Spell;
+  activeWindows?: CooldownWindow[];
 };
 
 const coreCooldowns: SpellCooldown[] = [
@@ -45,6 +47,7 @@ const longCooldowns: Cooldown[] = [
 ];
 
 const CoreCooldownsGraph = () => {
+  const VoidboltAnalyzer = useAnalyzer(Voidbolt);
   let coreCooldown = coreCooldowns;
   let message = (
     <Trans id="guide.priest.shadow.sections.corecooldowns.graphNOVB">
@@ -59,6 +62,10 @@ const CoreCooldownsGraph = () => {
   const info = useInfo();
   if (info!.combatant.hasTalent(TALENTS.VOID_ERUPTION_TALENT)) {
     coreCooldown = coreCooldownsVB;
+    // not the prettiest solution, but functional
+    coreCooldown.find((cd) => cd.spell.id === SPELLS.VOID_BOLT.id)!.activeWindows =
+      VoidboltAnalyzer?.executeRanges.map(fromExecuteRange);
+
     message = (
       <Trans id="guide.priest.shadow.sections.corecooldowns.graphVB">
         <strong>Core Spells</strong> - <SpellLink id={SPELLS.MIND_BLAST.id} /> is a core spell that
@@ -158,6 +165,7 @@ const CoreCooldownGraphSubsection = (cooldownsToCheck: SpellCooldown[], message:
           spellId={cooldownCheck.spell.id}
           gapHighlightMode={GapHighlight.None}
           minimizeIcons={hasTooManyCasts}
+          activeWindows={cooldownCheck.activeWindows}
         />
       ))}
     </SubSection>

--- a/src/parser/shared/modules/Enemies.ts
+++ b/src/parser/shared/modules/Enemies.ts
@@ -1,6 +1,6 @@
 import Enemy from 'parser/core/Enemy';
 import { TrackedBuffEvent } from 'parser/core/Entity';
-import { AnyEvent, HasSource, HasTarget } from 'parser/core/Events';
+import { AnyEvent, HasSource, HasTarget, SourcedEvent, TargettedEvent } from 'parser/core/Events';
 
 import Entities from './Entities';
 
@@ -11,6 +11,8 @@ type EnemyBuffHistory = {
   end: number;
 };
 
+export function encodeEventTargetString(event: TargettedEvent<any>): string;
+export function encodeEventTargetString(event: AnyEvent): string | null;
 export function encodeEventTargetString(event: AnyEvent) {
   if (!HasTarget(event)) {
     return null;
@@ -18,6 +20,8 @@ export function encodeEventTargetString(event: AnyEvent) {
   return encodeTargetString(event.targetID, event.targetInstance);
 }
 
+export function encodeEventSourceString(event: SourcedEvent<any>): string;
+export function encodeEventSourceString(event: AnyEvent): string | null;
 export function encodeEventSourceString(event: AnyEvent) {
   if (!HasSource(event)) {
     return null;

--- a/src/parser/shared/modules/helpers/ExecuteHelper.ts
+++ b/src/parser/shared/modules/helpers/ExecuteHelper.ts
@@ -531,8 +531,6 @@ class ExecuteHelper extends Analyzer {
       });
     }
 
-    console.log(this.executeRanges);
-
     debug &&
       console.log(
         'Fight ended, total duration of execute: ' +

--- a/src/parser/ui/CastEfficiencyBar.tsx
+++ b/src/parser/ui/CastEfficiencyBar.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { ReactNode } from 'react';
-import { CooldownBar, GapHighlight } from 'parser/ui/CooldownBar';
+import { CooldownBar } from 'parser/ui/CooldownBar';
 import { SpellIcon, SpellLink, TooltipElement } from 'interface';
 import { BadColor, GoodColor, MediocreColor, OkColor, useAnalyzer } from 'interface/guide';
 import CastEfficiency from 'parser/shared/modules/CastEfficiency';
@@ -22,11 +22,8 @@ export default function CastEfficiencyBar({
   minimizeIcons,
   useThresholds,
   slimLines,
-}: {
-  spellId: number;
-  gapHighlightMode: GapHighlight;
-  minimizeIcons?: boolean;
-  slimLines?: boolean;
+  activeWindows,
+}: React.ComponentProps<typeof CooldownBar> & {
   useThresholds?: boolean;
 }): JSX.Element {
   const castEffic = useAnalyzer(CastEfficiency)?.getCastEfficiencyForSpellId(spellId);
@@ -49,14 +46,17 @@ export default function CastEfficiencyBar({
       }
     }
 
+    const windowName =
+      activeWindows === undefined ? 'the encounter' : 'the time that it was usable';
+
     utilDisplay = formatPercentage(effectiveUtil, 0) + '%';
     tooltip = (
       <>
         You cast <SpellLink id={spellId} /> <strong>{castEffic.casts}</strong> out of{' '}
         <strong>{castEffic.maxCasts}</strong> possible times.
         <br />
-        It was on cooldown for <strong>{formatPercentage(castEffic.efficiency, 0)}%</strong> of the
-        encounter.
+        It was on cooldown for <strong>{formatPercentage(castEffic.efficiency, 0)}%</strong> of{' '}
+        {windowName}.
         <br />
         {gotMaxCasts && '(100% cast efficiency because you used the maximum possible casts)'}
       </>
@@ -71,6 +71,7 @@ export default function CastEfficiencyBar({
         </TooltipElement>
       </div>
       <CooldownBar
+        activeWindows={activeWindows}
         spellId={spellId}
         gapHighlightMode={gapHighlightMode}
         minimizeIcons={minimizeIcons}

--- a/src/parser/ui/CooldownBar.scss
+++ b/src/parser/ui/CooldownBar.scss
@@ -3,6 +3,14 @@
 .cooldown-bar {
   position: relative;
   width: 100%;
+  background: transparentize($color: $muted, $amount: 0.75);
+  height: 24px;
+}
+
+.cooldown-bar-window {
+  display: inline-block;
+  position: absolute;
+  width: 100%;
   height: 24px;
   background: $muted;
 

--- a/src/parser/ui/CooldownBar.tsx
+++ b/src/parser/ui/CooldownBar.tsx
@@ -9,6 +9,7 @@ import {
 } from 'parser/core/Events';
 import { useInfo, useEvents } from 'interface/guide';
 import { Fragment } from 'react';
+import { ExecuteRange } from 'parser/shared/modules/helpers/ExecuteHelper';
 
 /** If and where times the spell was available should be highlighted in red
  *  TODO add timed option?
@@ -26,6 +27,18 @@ export enum GapHighlight {
   All,
 }
 
+export type CooldownWindow = {
+  startTime: number;
+  endTime: number;
+};
+
+export function fromExecuteRange(range: ExecuteRange): CooldownWindow {
+  return {
+    startTime: range.startEvent.timestamp,
+    endTime: range.endEvent.timestamp,
+  };
+}
+
 type Props = {
   /** The spellId to show cooldown bars for - this must match the ID of the spell's cast event */
   spellId: number;
@@ -36,48 +49,56 @@ type Props = {
    *  be usable */
   minimizeIcons?: boolean;
   slimLines?: boolean;
+  /**
+   * Windows where the spell is actually usable. Useful for execute spells or spells that only become active inside of a cooldown.
+   *
+   * If not specified, defaults to the whole fight.
+   */
+  activeWindows?: Array<CooldownWindow>;
 };
 
-/**
- * Displays a bar with icons showing when a cooldown spell was used, and shading showing when the
- * spell was on cooldown vs when it was available.
- *
- * See docs for {@link Props} for explanation of parameters.
- */
-export function CooldownBar({
-  spellId,
+const CooldownBarWindow = ({
+  startTime,
+  endTime,
   gapHighlightMode,
   minimizeIcons,
+  spellId,
   slimLines,
   ...others
-}: Props): JSX.Element {
-  const info = useInfo()!;
+}: Omit<Props, 'activeWindows'> & CooldownWindow) => {
+  const { abilities, fightStart, fightEnd, fightDuration } = useInfo()!;
   const events = useEvents()!;
-  const ability = info.abilities.find(
+  const ability = abilities.find(
     (a) => a.spell === spellId || (Array.isArray(a.spell) && a.spell.includes(spellId)),
   );
   const abilityCdMs = (ability ? ability.cooldown : 0) * 1000;
   const abilityName = ability?.name || 'Unknown Ability';
   const hasCharges = ability && ability.charges > 1;
 
-  const endCooldowns: UpdateSpellUsableEvent[] = events.filter(
-    (event): event is UpdateSpellUsableEvent =>
-      IsUpdateSpellUsable(event) &&
-      event.ability.guid === spellId &&
-      event.updateType === UpdateSpellUsableType.EndCooldown,
-  );
-  const useCharges: UpdateSpellUsableEvent[] = events.filter(
-    (event): event is UpdateSpellUsableEvent =>
-      IsUpdateSpellUsable(event) &&
-      event.ability.guid === spellId &&
-      event.updateType === UpdateSpellUsableType.UseCharge,
-  );
+  const endCooldowns: UpdateSpellUsableEvent[] = events
+    .filter((event) => event.timestamp >= startTime)
+    .filter(
+      (event): event is UpdateSpellUsableEvent =>
+        IsUpdateSpellUsable(event) &&
+        event.ability.guid === spellId &&
+        event.updateType === UpdateSpellUsableType.EndCooldown,
+    );
+  const useCharges: UpdateSpellUsableEvent[] = events
+    .filter((event) => event.timestamp >= startTime && event.timestamp <= endTime)
+    .filter(
+      (event): event is UpdateSpellUsableEvent =>
+        IsUpdateSpellUsable(event) &&
+        event.ability.guid === spellId &&
+        event.updateType === UpdateSpellUsableType.UseCharge,
+    );
 
   const segmentProps = {
     gapHighlightMode,
     minimizeIcons,
-    fightStart: info.fightStart,
-    fightEnd: info.fightEnd,
+    windowStart: startTime,
+    windowEnd: endTime,
+    fightStart,
+    fightEnd,
     abilityId: spellId,
     abilityCdMs,
     abilityName,
@@ -85,9 +106,16 @@ export function CooldownBar({
     slimLines,
   };
 
-  let lastAvailable = info.fightStart;
+  let lastAvailable = startTime;
   return (
-    <div className="cooldown-bar" {...others}>
+    <div
+      className="cooldown-bar-window"
+      {...others}
+      style={{
+        left: `${((startTime - fightStart) / fightDuration) * 100}%`,
+        width: `${((endTime - startTime) / fightDuration) * 100}%`,
+      }}
+    >
       {endCooldowns.length === 0 && (
         <Tooltip
           key="available"
@@ -109,7 +137,7 @@ export function CooldownBar({
       )}
       {endCooldowns.map((cd, ix) => {
         // end cooldown events can be placed after fight end, so we need to clip the bars
-        const end = cd.timestamp > info.fightEnd ? info.fightEnd : cd.timestamp;
+        const end = cd.timestamp > endTime ? endTime : cd.timestamp;
         const currLastAvailable = lastAvailable;
         lastAvailable = end;
         // render the last period of availablility and also this cooldown
@@ -132,23 +160,43 @@ export function CooldownBar({
           </Fragment>
         );
       })}
-      {endCooldowns.length !== 0 && lastAvailable !== info.fightEnd && (
+      {endCooldowns.length !== 0 && lastAvailable !== endTime && (
         <CooldownBarSegment
           startTimestamp={lastAvailable}
-          endTimestamp={info.fightEnd}
+          endTimestamp={endTime}
           type="available"
           key="end-available"
           {...segmentProps}
         />
       )}
       {useCharges.map((cd, ix) => {
-        const left = `${((cd.timestamp - info.fightStart) / info.fightDuration) * 100}%`;
+        const left = `${((cd.timestamp - startTime) / (endTime - startTime)) * 100}%`;
         return (
           <div style={{ left }} key={ix + '-usecharge'}>
             {iconOrChip(spellId, minimizeIcons, slimLines)}
           </div>
         );
       })}
+    </div>
+  );
+};
+
+/**
+ * Displays a bar with icons showing when a cooldown spell was used, and shading showing when the
+ * spell was on cooldown vs when it was available.
+ *
+ * See docs for {@link Props} for explanation of parameters.
+ */
+export function CooldownBar({ activeWindows, ...others }: Props): JSX.Element {
+  const info = useInfo()!;
+
+  const windows = activeWindows ?? [{ startTime: info.fightStart, endTime: info.fightEnd }];
+
+  return (
+    <div className="cooldown-bar">
+      {windows.map((win) => (
+        <CooldownBarWindow key={`${win.startTime}-${win.endTime}`} {...others} {...win} />
+      ))}
     </div>
   );
 }
@@ -159,6 +207,8 @@ function CooldownBarSegment({
   abilityCdMs,
   startTimestamp,
   endTimestamp,
+  windowStart,
+  windowEnd,
   fightStart,
   fightEnd,
   type,
@@ -172,16 +222,20 @@ function CooldownBarSegment({
   abilityCdMs: number;
   startTimestamp: number;
   endTimestamp: number;
+  // used for tooltip formatting
   fightStart: number;
   fightEnd: number;
+  // used for position calculation
+  windowStart: number;
+  windowEnd: number;
   type: 'onCooldown' | 'available';
   gapHighlightMode: GapHighlight;
   minimizeIcons?: boolean;
   slimLines?: boolean;
   hasCharges?: boolean;
 }): JSX.Element {
-  const fightDuration = fightEnd - fightStart;
-  const left = `${((startTimestamp - fightStart) / fightDuration) * 100}%`;
+  const fightDuration = windowEnd - windowStart;
+  const left = `${((startTimestamp - windowStart) / fightDuration) * 100}%`;
   const width = `${((endTimestamp - startTimestamp) / fightDuration) * 100}%`;
 
   const openForFullCooldown =


### PR DESCRIPTION
### Description

This adds the concept of an "active window" to `CooldownBar` + `CastEfficiencyBar`, which indicates a window of time where the spell is actually usable.

This is motivated by Void Bolt in specific, and Execute-like spells in general. This  includes additions to `ExecuteHelper` to build up these active window ranges during analysis.

### Testing

I tested on the example report for Shadow Priest. This is what it looks like

![image](https://user-images.githubusercontent.com/4909458/233789991-2389bf37-a182-4a02-afc8-754335270327.png)
